### PR TITLE
Use the correct permalink for posts on page 2 of a topic

### DIFF
--- a/dhqa_data.py
+++ b/dhqa_data.py
@@ -64,8 +64,10 @@ def get_post_info(div, topic_url, feed, page_url=None):
     [comment.extract() for comment in threadpost.findAll(
         text=lambda text:isinstance(text, Comment))]
 
-    # get post content
-    info['content'] = threadpost.div.prettify()
+    # get post html content
+    info['html_content'] = threadpost.div.prettify()
+    # extract text from post on html page
+    info['content'] = threadpost.div.get_text()
 
     # check if this is a reply to a specific post
     if threadpost.p and threadpost.p.get_text().startswith('Replying to'):

--- a/dhqa_data.py
+++ b/dhqa_data.py
@@ -178,13 +178,17 @@ for path in glob.glob('topic/*/index.html'):
         next_link = soup.find('a', class_='next')
         if next_link:
             page_two = '%s/index.html' % next_link['href'].lstrip('/')
+            # post permalink and RSS links are relative to the page
+            page_url = 'http://digitalhumanities.org/answers%s' % \
+                next_link['href']
+
+            # page two capture date could be different
+            capture_date = wayback_machine_timestamp(page_url)
+            topic_data['snapshot_date'] = capture_date or ''
             with open(page_two) as page_two_doc:
                 soup2 = BeautifulSoup(page_two_doc, 'html.parser')
                 posts = soup2.findAll('li', id=re.compile(r'^post-\d+'))
                 for post in posts:
-                    # post permalink and RSS links are relative to the page
-                    page_url = 'http://digitalhumanities.org/answers%s' % \
-                        next_link['href']
                     post_data = get_post_info(post, topic_url, feed,
                                               page_url=page_url)
                     post_data.update(topic_data)


### PR DESCRIPTION
Revises the code to use the correct permalink for posts on page 2 of a topic, which has the added benefit that we should be retrieving dates for them from the RSS feeds where they're present (previously they didn't match since the URL was wrong).